### PR TITLE
Add new builds Tasks dotnet core

### DIFF
--- a/generators/vsts/index.js
+++ b/generators/vsts/index.js
@@ -113,7 +113,6 @@ function writeFiles() {
    if (this.type === 'asp') {
       this.copy(this.sourceRoot() + '/asp_arm.json', this.applicationName + '/templates/website.json');
       this.copy(this.sourceRoot() + '/arm.parameters.json', this.applicationName + '/templates/website.parameters.json');
-      this.copy(this.sourceRoot() + '/parameters.xml', this.applicationName + '/templates/parameters.xml');
    } else if (this.type === 'node') {
       this.copy(this.sourceRoot() + '/node_arm.json', this.applicationName + '/templates/website.json');
       this.copy(this.sourceRoot() + '/arm.parameters.json', this.applicationName + '/templates/website.parameters.json');

--- a/generators/vsts/templates/asp_build.json
+++ b/generators/vsts/templates/asp_build.json
@@ -37,24 +37,10 @@
          },
          "inputs": {
             "command": "restore",
-            "projects": "**/project.json"
-         }
-      },
-      {
-         "enabled": true,
-         "continueOnError": false,
-         "alwaysRun": false,
-         "displayName": "Build",
-         "timeoutInMinutes": 0,
-         "task": {
-            "id": "5541a522-603c-47ad-91fc-a4b1d163081b",
-            "versionSpec": "*",
-            "definitionType": "task"
-         },
-         "inputs": {
-            "command": "build",
+            "publishWebProjects": "true",
             "projects": "**/project.json",
-            "arguments": "--configuration $(BuildConfiguration)"
+            "arguments": "--no-cache",
+            "zipAfterPublish": "true"
          }
       },
       {
@@ -163,9 +149,10 @@
          },
          "inputs": {
             "command": "publish",
-            "publishWebProjects": "True",
-            "zipAfterPublish": "True",
-            "arguments": "--configuration $(BuildConfiguration) --output $(Build.StagingDirectory)/pub"
+            "publishWebProjects": "true",
+            "projects": "",
+            "arguments": "--configuration $(BuildConfiguration) --output $(Build.StagingDirectory)/pub",
+            "zipAfterPublish": "true"
          }
       },
       {
@@ -199,11 +186,34 @@
             "definitionType": "task"
          },
          "inputs": {
-            "CopyRoot": "",
+            "CopyRoot": "$(Build.StagingDirectory)/pub",
             "Contents": "**/*.zip\n**/templates/*.*",
             "ArtifactName": "drop",
             "ArtifactType": "Container",
             "TargetPath": "\\\\my\\share\\$(Build.DefinitionName)\\$(Build.BuildNumber)"
+         }
+      }
+   ],
+   "options": [
+      {
+         "enabled": false,
+         "definition": {
+            "id": "7c555368-ca64-4199-add6-9ebaf0b0137d"
+         },
+         "inputs": {
+            "multipliers": "[]",
+            "parallel": "false",
+            "continueOnError": "true",
+            "additionalFields": "{}"
+         }
+      },
+      {
+         "enabled": false,
+         "definition": {
+            "id": "57578776-4c22-4526-aeb0-86b6da17ee9c"
+         },
+         "inputs": {
+            "additionalFields": "{}"
          }
       }
    ],
@@ -243,7 +253,11 @@
    "repository": {
       "properties": {
          "labelSources": "0",
-         "reportBuildStatus": "true"
+         "reportBuildStatus": "true",
+         "fetchDepth": "0",
+         "gitLfsSupport": "false",
+         "skipSyncSource": "false",
+         "cleanOptions": "0"
       },
       "type": "TfsGit",
       "name": "{{Project}}",

--- a/generators/vsts/templates/asp_build.json
+++ b/generators/vsts/templates/asp_build.json
@@ -28,18 +28,33 @@
          "enabled": true,
          "continueOnError": false,
          "alwaysRun": false,
-         "displayName": "Run dotnet restore",
+         "displayName": "Restore",
          "timeoutInMinutes": 0,
          "task": {
-            "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+            "id": "5541a522-603c-47ad-91fc-a4b1d163081b",
             "versionSpec": "*",
             "definitionType": "task"
          },
          "inputs": {
-            "filename": "dotnet",
-            "arguments": "restore --no-cache",
-            "workingFolder": "",
-            "failOnStandardError": "false"
+            "command": "restore",
+            "projects": "**/project.json"
+         }
+      },
+      {
+         "enabled": true,
+         "continueOnError": false,
+         "alwaysRun": false,
+         "displayName": "Build",
+         "timeoutInMinutes": 0,
+         "task": {
+            "id": "5541a522-603c-47ad-91fc-a4b1d163081b",
+            "versionSpec": "*",
+            "definitionType": "task"
+         },
+         "inputs": {
+            "command": "build",
+            "projects": "**/project.json",
+            "arguments": "--configuration $(BuildConfiguration)"
          }
       },
       {
@@ -139,18 +154,18 @@
          "enabled": true,
          "continueOnError": false,
          "alwaysRun": false,
-         "displayName": "Run dotnet publish",
+         "displayName": "Publish",
          "timeoutInMinutes": 0,
          "task": {
-            "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+            "id": "5541a522-603c-47ad-91fc-a4b1d163081b",
             "versionSpec": "*",
             "definitionType": "task"
          },
          "inputs": {
-            "filename": "dotnet",
-            "arguments": "publish -c $(BuildConfiguration) -o $(Build.StagingDirectory)/pub",
-            "workingFolder": "src/{{Project}}",
-            "failOnStandardError": "false"
+            "command": "publish",
+            "publishWebProjects": "True",
+            "zipAfterPublish": "True",
+            "arguments": "--configuration $(BuildConfiguration) --output $(Build.StagingDirectory)/pub"
          }
       },
       {
@@ -170,26 +185,6 @@
             "TargetFolder": "$(Build.StagingDirectory)/pub",
             "CleanTargetFolder": "false",
             "OverWrite": "false"
-         }
-      },
-      {
-         "enabled": true,
-         "continueOnError": false,
-         "alwaysRun": false,
-         "displayName": "Archive files ",
-         "timeoutInMinutes": 0,
-         "task": {
-            "id": "d8b84976-e99a-4b86-b885-4849694435b0",
-            "versionSpec": "*",
-            "definitionType": "task"
-         },
-         "inputs": {
-            "rootFolder": "$(Build.StagingDirectory)/pub",
-            "includeRootFolder": "false",
-            "archiveType": "default",
-            "tarCompression": "gz",
-            "archiveFile": "website.zip",
-            "replaceExistingArchive": "true"
          }
       },
       {

--- a/generators/vsts/templates/asp_build.json
+++ b/generators/vsts/templates/asp_build.json
@@ -172,7 +172,7 @@
          "enabled": true,
          "continueOnError": false,
          "alwaysRun": false,
-         "displayName": "Copy parameters.xml to publish folder",
+         "displayName": "Copy parameters.xml and json files to publish folder",
          "timeoutInMinutes": 0,
          "task": {
             "id": "5bfb729a-a7c8-4a78-a7c3-8d717bb7c13c",
@@ -181,8 +181,8 @@
          },
          "inputs": {
             "SourceFolder": "templates/",
-            "Contents": "**/parameters.xml",
-            "TargetFolder": "$(Build.StagingDirectory)/pub",
+            "Contents": "**/*.*",
+            "TargetFolder": "$(Build.StagingDirectory)/pub/templates/",
             "CleanTargetFolder": "false",
             "OverWrite": "false"
          }

--- a/generators/vsts/templates/asp_build.json
+++ b/generators/vsts/templates/asp_build.json
@@ -159,7 +159,7 @@
          "enabled": true,
          "continueOnError": false,
          "alwaysRun": false,
-         "displayName": "Copy parameters.xml and json files to publish folder",
+         "displayName": "Copy ARM template files to publish folder",
          "timeoutInMinutes": 0,
          "task": {
             "id": "5bfb729a-a7c8-4a78-a7c3-8d717bb7c13c",
@@ -168,10 +168,10 @@
          },
          "inputs": {
             "SourceFolder": "templates/",
-            "Contents": "**/*.*",
+            "Contents": "**/*.json",
             "TargetFolder": "$(Build.StagingDirectory)/pub/templates/",
             "CleanTargetFolder": "false",
-            "OverWrite": "false"
+            "OverWrite": "true"
          }
       },
       {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
    "name": "generator-vsts",
-   "version": "0.2.1",
+   "version": "0.2.2",
    "description": "Generates an app with CI/CD in Visual Studio Team Services",
    "main": "./generators/app/index.js",
    "scripts": {


### PR DESCRIPTION
In asp net build CI, I updated the cmd tasks (for restore, build and publish commands) with the new DotNet Core build tasks.

![image](https://cloud.githubusercontent.com/assets/2725302/20572041/158cc6d0-b1aa-11e6-8c33-64d2aa400101.png)
